### PR TITLE
added cookiecontroller setting session ID cookie

### DIFF
--- a/server/controllers/cookieController.js
+++ b/server/controllers/cookieController.js
@@ -1,0 +1,13 @@
+const cookieController = {};
+
+cookieController.setSSIDCookie = (req, res, next) => {
+  const id = res.locals.id;
+  res.cookie('ssid', id, {
+    httpOnly: true,
+    secure: true,
+    maxAge: 3600000, // cookie should last one hour
+  });
+  return next();
+};
+
+module.exports = cookieController;


### PR DESCRIPTION
added code to the cookieController
- added a setSSIDCookie function
- sends a cookie with key ssid and value of the user id which is saved in the res.locals.id
- cookie is httpOnly, secure and has a maxAge of 1 hour. 
- return next is added to move to next piece of middleware
- cookieController is exported