### PR TITLE
delete a thread and its messages by event id

### DIFF
--- a/server/controllers/threadController.js
+++ b/server/controllers/threadController.js
@@ -89,4 +89,23 @@ threadController.getThreadMessages = async (req, res, next) => {
   }
 };
 
+threadController.deleteThread = async (req, res, next) => {
+
+  const eventId = req.params.eventid
+  const deleteParam = [eventId];
+  const queryDeleteThread = 'DELETE FROM threads WHERE event_id = $1;';
+
+  try {
+    await db.query(queryDeleteThread, deleteParam);
+    return next()
+  } catch (err) {
+    return next({
+      log: `Error in threadController.deleteThread: ${err}`,
+      message: {
+        err: `Error in the backend from threadController.deleteThread`
+      }
+    });
+  }
+};
+
 module.exports = threadController;

--- a/server/routes/thread.js
+++ b/server/routes/thread.js
@@ -2,7 +2,7 @@ const express = require('express');
 const threadController = require('../controllers/threadController');
 
 const router = express.Router();
-const { createPost, getUpcomingEvents, getThreadMessages } = threadController;
+const { createPost, getUpcomingEvents, getThreadMessages, deleteThread } = threadController;
 
 router.post('/', createPost, (req, res) => {
   return res
@@ -24,5 +24,11 @@ router.get('/:id', getThreadMessages, (req, res) => {
     .status(200)
     .json(res.locals.threadMessages)
 });
+
+router.delete('/:eventid', deleteThread, (req, res) => {
+  return res
+    .status(200)
+    .send('Thread successfully deleted')
+})
 
 module.exports = router;


### PR DESCRIPTION
-added route in thread.js to delete a thread, grabbing eventid from req.params
-added deleteThread middleware in threadController
-this will grab the event id from req params and delete all threads in db with that event id, that way the thread and all its messages are deleted (not just deleted one comment)
-tested with postman and thread with its corresponding replies were successfully deleted from db 